### PR TITLE
Feat: 회원 가입 및 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,11 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // auth
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.mockito:mockito-core:5.4.0'

--- a/src/main/java/wanted/assignment/common/annotation/JwtAuthorization.java
+++ b/src/main/java/wanted/assignment/common/annotation/JwtAuthorization.java
@@ -1,0 +1,14 @@
+package wanted.assignment.common.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface JwtAuthorization {
+
+}

--- a/src/main/java/wanted/assignment/common/config/WebMvcConfig.java
+++ b/src/main/java/wanted/assignment/common/config/WebMvcConfig.java
@@ -1,0 +1,22 @@
+package wanted.assignment.common.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import lombok.RequiredArgsConstructor;
+import wanted.assignment.common.config.jwt.JwtAuthorizationArgumentResolver;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	private final JwtAuthorizationArgumentResolver jwtAuthorizationArgumentResolver;
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(jwtAuthorizationArgumentResolver);
+	}
+}

--- a/src/main/java/wanted/assignment/common/config/jwt/JwtAuthTokenProvider.java
+++ b/src/main/java/wanted/assignment/common/config/jwt/JwtAuthTokenProvider.java
@@ -1,0 +1,83 @@
+package wanted.assignment.common.config.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import wanted.assignment.common.error.exception.jwt.CustomJwtTokenException;
+import wanted.assignment.common.generator.TimeGenerator;
+
+@Slf4j
+@Getter
+@Component
+public class JwtAuthTokenProvider {
+
+	@Value("${jwt.secret}")
+	private String secret;
+
+	@Value("${jwt.expired_minutes}")
+	private Integer expiredMinutes;
+
+	public boolean validateToken(String token) {
+		try {
+			return !Jwts.parserBuilder()
+				.setSigningKey(getHashingKey())
+				.build()
+				.parseClaimsJws(removeBearer(token))
+				.getBody()
+				.getExpiration().before(new Date());
+		} catch (Exception e) {
+			throw new CustomJwtTokenException("토큰 검증 실패");
+		}
+	}
+
+	public MemberTokenInfo parsingTokenToMember(String token) {
+		try {
+			Claims body = Jwts.parserBuilder()
+				.setSigningKey(getHashingKey()).build()
+				.parseClaimsJws(removeBearer(token))
+				.getBody();
+
+			Long id = Long.parseLong(body.get("id", String.class));
+			String email = body.get("email", String.class);
+
+			return MemberTokenInfo.builder()
+				.id(id)
+				.email(email)
+				.build();
+		} catch (RuntimeException e) {
+			throw new CustomJwtTokenException("토큰 검증 실패");
+		}
+	}
+
+	public String createJwtAuthToken(Long id, String email) {
+		Claims claims = Jwts.claims();
+		claims.put("id", id.toString());
+		claims.put("email", email);
+
+		return Jwts.builder()
+			.setHeaderParam("typ", "JWT")
+			.setClaims(claims)
+			.signWith(getHashingKey(), SignatureAlgorithm.HS256)
+			.setExpiration(TimeGenerator.getTimeInFuture(expiredMinutes))
+			.compact();
+	}
+
+	private String removeBearer(String token) {
+		return token.replace("Bearer", "").trim();
+	}
+
+	private SecretKey getHashingKey() {
+		return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+	}
+}

--- a/src/main/java/wanted/assignment/common/config/jwt/JwtAuthorizationArgumentResolver.java
+++ b/src/main/java/wanted/assignment/common/config/jwt/JwtAuthorizationArgumentResolver.java
@@ -1,0 +1,47 @@
+package wanted.assignment.common.config.jwt;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import lombok.RequiredArgsConstructor;
+import wanted.assignment.common.annotation.JwtAuthorization;
+import wanted.assignment.common.error.exception.jwt.CustomJwtTokenException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthorizationArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Value("${jwt.header}")
+	private String header;
+
+	private final JwtAuthTokenProvider jwtAuthTokenProvider;
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(JwtAuthorization.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+		HttpServletRequest httpServletRequest = webRequest.getNativeRequest(HttpServletRequest.class);
+
+		if (httpServletRequest != null) {
+			String token = httpServletRequest.getHeader(header);
+
+			if (jwtAuthTokenProvider.validateToken(token)) {
+				return jwtAuthTokenProvider.parsingTokenToMember(token);
+			}
+		}
+
+		throw new CustomJwtTokenException("토큰 검증 실패");
+	}
+}

--- a/src/main/java/wanted/assignment/common/config/jwt/MemberTokenInfo.java
+++ b/src/main/java/wanted/assignment/common/config/jwt/MemberTokenInfo.java
@@ -1,0 +1,18 @@
+package wanted.assignment.common.config.jwt;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberTokenInfo {
+
+	private final Long id;
+	private final String email;
+
+	@Builder
+	private MemberTokenInfo(Long id, String email) {
+		this.id = id;
+		this.email = email;
+	}
+}
+

--- a/src/main/java/wanted/assignment/common/error/ErrorController.java
+++ b/src/main/java/wanted/assignment/common/error/ErrorController.java
@@ -7,13 +7,20 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import wanted.assignment.common.basewrapper.ApiResult;
+import wanted.assignment.common.error.exception.member.DuplicateEmailException;
 
 @RestControllerAdvice
 public class ErrorController {
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(DuplicateEmailException.class)
+	public ApiResult<Void> handlerDuplicateEmailException(DuplicateEmailException e) {
+		return ApiResult.onFailure(e.getLocalizedMessage());
+	}
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(MethodArgumentNotValidException.class)
-	public ApiResult<Void> handlerValidationRequest(MethodArgumentNotValidException e) {
+	public ApiResult<Void> handlerValidationException(MethodArgumentNotValidException e) {
 		return ApiResult.onFailure(e.getBindingResult().getAllErrors().get(0).getDefaultMessage());
 	}
 }

--- a/src/main/java/wanted/assignment/common/error/ErrorController.java
+++ b/src/main/java/wanted/assignment/common/error/ErrorController.java
@@ -7,14 +7,22 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import wanted.assignment.common.basewrapper.ApiResult;
+import wanted.assignment.common.error.exception.jwt.CustomJwtTokenException;
 import wanted.assignment.common.error.exception.member.DuplicateEmailException;
+import wanted.assignment.common.error.exception.member.PasswordMismatchException;
 
 @RestControllerAdvice
 public class ErrorController {
 
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	@ExceptionHandler(DuplicateEmailException.class)
-	public ApiResult<Void> handlerDuplicateEmailException(DuplicateEmailException e) {
+	@ExceptionHandler({DuplicateEmailException.class, PasswordMismatchException.class})
+	public ApiResult<Void> handlerDuplicateEmailException(RuntimeException e) {
+		return ApiResult.onFailure(e.getLocalizedMessage());
+	}
+
+	@ResponseStatus(HttpStatus.FORBIDDEN)
+	@ExceptionHandler(CustomJwtTokenException.class)
+	public ApiResult<Void> handlerCustomJwtTokenException(CustomJwtTokenException e) {
 		return ApiResult.onFailure(e.getLocalizedMessage());
 	}
 

--- a/src/main/java/wanted/assignment/common/error/exception/jwt/CustomJwtTokenException.java
+++ b/src/main/java/wanted/assignment/common/error/exception/jwt/CustomJwtTokenException.java
@@ -1,0 +1,7 @@
+package wanted.assignment.common.error.exception.jwt;
+
+public class CustomJwtTokenException extends RuntimeException {
+	public CustomJwtTokenException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/wanted/assignment/common/error/exception/member/DuplicateEmailException.java
+++ b/src/main/java/wanted/assignment/common/error/exception/member/DuplicateEmailException.java
@@ -1,0 +1,7 @@
+package wanted.assignment.common.error.exception.member;
+
+public class DuplicateEmailException extends RuntimeException {
+	public DuplicateEmailException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/wanted/assignment/common/error/exception/member/PasswordMismatchException.java
+++ b/src/main/java/wanted/assignment/common/error/exception/member/PasswordMismatchException.java
@@ -1,0 +1,7 @@
+package wanted.assignment.common.error.exception.member;
+
+public class PasswordMismatchException extends RuntimeException {
+	public PasswordMismatchException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/wanted/assignment/common/generator/Sha256Util.java
+++ b/src/main/java/wanted/assignment/common/generator/Sha256Util.java
@@ -1,0 +1,46 @@
+package wanted.assignment.common.generator;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class Sha256Util {
+
+	private static final String ENCRYPTION_TYPE = "SHA-256";
+
+	public static String getEncrypt(String source) {
+		String salt = generateSalt();
+
+		return getEncrypt(source, salt.getBytes());
+	}
+
+	private static String getEncrypt(String source, byte[] salt) {
+		try {
+			MessageDigest messageDigest = MessageDigest.getInstance(ENCRYPTION_TYPE);
+			byte[] bytes = new byte[source.getBytes().length + salt.length];
+			byte[] byteData = messageDigest.digest(bytes);
+
+			return IntStream.range(0, byteData.length)
+				.mapToObj(n -> String.format("%02x", byteData[n]))
+				.collect(Collectors.joining());
+		} catch (NoSuchAlgorithmException e) {
+			throw new RuntimeException("SHA-256 암호화 에러");
+		}
+	}
+
+	private static String generateSalt() {
+		ThreadLocalRandom random = ThreadLocalRandom.current();
+
+		byte[] salt = new byte[8];
+		random.nextBytes(salt);
+
+		StringBuffer sb = new StringBuffer();
+		for (byte b : salt) {
+			sb.append(String.format("%02x", b));
+		}
+
+		return sb.toString();
+	}
+}

--- a/src/main/java/wanted/assignment/common/generator/TimeGenerator.java
+++ b/src/main/java/wanted/assignment/common/generator/TimeGenerator.java
@@ -2,10 +2,17 @@ package wanted.assignment.common.generator;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 
 public class TimeGenerator {
 
 	public static Timestamp getCurrentDateTime() {
 		return Timestamp.valueOf(LocalDateTime.now());
+	}
+
+	public static Date getTimeInFuture(Integer minute) {
+		return Date.from(
+			LocalDateTime.now().plusMinutes(minute).atZone(ZoneId.systemDefault()).toInstant());
 	}
 }

--- a/src/main/java/wanted/assignment/member/dao/MemberRepository.java
+++ b/src/main/java/wanted/assignment/member/dao/MemberRepository.java
@@ -1,5 +1,7 @@
 package wanted.assignment.member.dao;
 
+import java.util.Optional;
+
 import wanted.assignment.member.dao.domain.Member;
 
 public interface MemberRepository {
@@ -7,6 +9,8 @@ public interface MemberRepository {
 	Long save(Member member);
 
 	Member findById(Long id);
+
+	Optional<Member> findByEmail(String email);
 
 	Long update(Long id, Member member);
 

--- a/src/main/java/wanted/assignment/member/dao/MemberRepository.java
+++ b/src/main/java/wanted/assignment/member/dao/MemberRepository.java
@@ -1,0 +1,14 @@
+package wanted.assignment.member.dao;
+
+import wanted.assignment.member.dao.domain.Member;
+
+public interface MemberRepository {
+
+	Long save(Member member);
+
+	Member findById(Long id);
+
+	Long update(Long id, Member member);
+
+	void delete(Long id);
+}

--- a/src/main/java/wanted/assignment/member/dao/domain/Member.java
+++ b/src/main/java/wanted/assignment/member/dao/domain/Member.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import wanted.assignment.common.generator.Sha256Util;
 import wanted.assignment.member.service.request.MemberCreateServiceRequest;
+import wanted.assignment.member.web.response.MemberSignInResponse;
 
 @Getter
 public class Member {
@@ -24,6 +25,14 @@ public class Member {
 		return Member.builder()
 			.email(request.getEmail())
 			.password(encryptPassword)
+			.build();
+	}
+
+	public MemberSignInResponse getSignInResponse(String jwtAuthToken) {
+		return MemberSignInResponse.builder()
+			.id(this.id)
+			.email(this.email)
+			.token(jwtAuthToken)
 			.build();
 	}
 }

--- a/src/main/java/wanted/assignment/member/dao/domain/Member.java
+++ b/src/main/java/wanted/assignment/member/dao/domain/Member.java
@@ -1,0 +1,18 @@
+package wanted.assignment.member.dao.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Member {
+
+	private Long id;
+	private final String email;
+	private final String password;
+
+	@Builder
+	private Member(String email, String password) {
+		this.email = email;
+		this.password = password;
+	}
+}

--- a/src/main/java/wanted/assignment/member/dao/domain/Member.java
+++ b/src/main/java/wanted/assignment/member/dao/domain/Member.java
@@ -2,6 +2,8 @@ package wanted.assignment.member.dao.domain;
 
 import lombok.Builder;
 import lombok.Getter;
+import wanted.assignment.common.generator.Sha256Util;
+import wanted.assignment.member.service.request.MemberCreateServiceRequest;
 
 @Getter
 public class Member {
@@ -14,5 +16,14 @@ public class Member {
 	private Member(String email, String password) {
 		this.email = email;
 		this.password = password;
+	}
+
+	public static Member createFromServiceRequest(MemberCreateServiceRequest request) {
+		String encryptPassword = Sha256Util.getEncrypt(request.getPassword());
+
+		return Member.builder()
+			.email(request.getEmail())
+			.password(encryptPassword)
+			.build();
 	}
 }

--- a/src/main/java/wanted/assignment/member/dao/mybatis/MemberMapper.java
+++ b/src/main/java/wanted/assignment/member/dao/mybatis/MemberMapper.java
@@ -1,0 +1,21 @@
+package wanted.assignment.member.dao.mybatis;
+
+import java.util.Optional;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import wanted.assignment.common.basewrapper.BaseEntity;
+import wanted.assignment.member.dao.domain.Member;
+
+@Mapper
+public interface MemberMapper {
+
+	void save(BaseEntity<Member> member);
+
+	Optional<Member> findById(Long id);
+
+	void update(@Param("id") Long id, @Param("updateParam") BaseEntity<Member> member);
+
+	void delete(Long id);
+}

--- a/src/main/java/wanted/assignment/member/dao/mybatis/MemberMapper.java
+++ b/src/main/java/wanted/assignment/member/dao/mybatis/MemberMapper.java
@@ -15,6 +15,8 @@ public interface MemberMapper {
 
 	Optional<Member> findById(Long id);
 
+	Optional<Member> findByEmail(String email);
+
 	void update(@Param("id") Long id, @Param("updateParam") BaseEntity<Member> member);
 
 	void delete(Long id);

--- a/src/main/java/wanted/assignment/member/dao/mybatis/MyBatisMemberRepository.java
+++ b/src/main/java/wanted/assignment/member/dao/mybatis/MyBatisMemberRepository.java
@@ -1,0 +1,44 @@
+package wanted.assignment.member.dao.mybatis;
+
+import java.util.NoSuchElementException;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import wanted.assignment.common.basewrapper.BaseEntity;
+import wanted.assignment.member.dao.MemberRepository;
+import wanted.assignment.member.dao.domain.Member;
+
+@Repository
+@RequiredArgsConstructor
+public class MyBatisMemberRepository implements MemberRepository {
+
+	private final MemberMapper memberMapper;
+
+	@Override
+	public Long save(Member member) {
+		BaseEntity<Member> createData = BaseEntity.createData(member);
+		memberMapper.save(createData);
+
+		return createData.getData().getId();
+	}
+
+	@Override
+	public Member findById(Long id) {
+		return memberMapper.findById(id)
+			.orElseThrow(() -> new NoSuchElementException("해당 Id의 회원은 존재하지 않습니다."));
+	}
+
+	@Override
+	public Long update(Long id, Member member) {
+		BaseEntity<Member> updateData = BaseEntity.updateData(member);
+		memberMapper.update(id, updateData);
+
+		return id;
+	}
+
+	@Override
+	public void delete(Long id) {
+		memberMapper.delete(id);
+	}
+}

--- a/src/main/java/wanted/assignment/member/dao/mybatis/MyBatisMemberRepository.java
+++ b/src/main/java/wanted/assignment/member/dao/mybatis/MyBatisMemberRepository.java
@@ -1,6 +1,7 @@
 package wanted.assignment.member.dao.mybatis;
 
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
@@ -27,6 +28,11 @@ public class MyBatisMemberRepository implements MemberRepository {
 	public Member findById(Long id) {
 		return memberMapper.findById(id)
 			.orElseThrow(() -> new NoSuchElementException("해당 Id의 회원은 존재하지 않습니다."));
+	}
+
+	@Override
+	public Optional<Member> findByEmail(String email) {
+		return memberMapper.findByEmail(email);
 	}
 
 	@Override

--- a/src/main/java/wanted/assignment/member/service/MemberService.java
+++ b/src/main/java/wanted/assignment/member/service/MemberService.java
@@ -26,7 +26,7 @@ public class MemberService {
 		return memberRepository.save(member);
 	}
 
-	public Member signIn(String email, String password) {
+	public Member login(String email, String password) {
 		Member member = getMemberByEmail(email);
 		checkPassword(member, password);
 

--- a/src/main/java/wanted/assignment/member/service/MemberService.java
+++ b/src/main/java/wanted/assignment/member/service/MemberService.java
@@ -1,8 +1,11 @@
 package wanted.assignment.member.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import wanted.assignment.common.error.exception.member.DuplicateEmailException;
 import wanted.assignment.member.dao.MemberRepository;
 import wanted.assignment.member.dao.domain.Member;
 import wanted.assignment.member.service.request.MemberCreateServiceRequest;
@@ -14,7 +17,19 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 
 	public Long join(MemberCreateServiceRequest request) {
+		boolean isDuplicateEmail = checkDuplicateEmail(request.getEmail());
+
+		if (isDuplicateEmail) {
+			throw new DuplicateEmailException("이미 사용 중인 이메일입니다.");
+		}
+
 		Member member = Member.createFromServiceRequest(request);
 		return memberRepository.save(member);
+	}
+
+	private boolean checkDuplicateEmail(String email) {
+		Optional<Member> findEmailOptional = memberRepository.findByEmail(email);
+
+		return findEmailOptional.isPresent();
 	}
 }

--- a/src/main/java/wanted/assignment/member/service/MemberService.java
+++ b/src/main/java/wanted/assignment/member/service/MemberService.java
@@ -1,0 +1,20 @@
+package wanted.assignment.member.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import wanted.assignment.member.dao.MemberRepository;
+import wanted.assignment.member.dao.domain.Member;
+import wanted.assignment.member.service.request.MemberCreateServiceRequest;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+
+	public Long join(MemberCreateServiceRequest request) {
+		Member member = Member.createFromServiceRequest(request);
+		return memberRepository.save(member);
+	}
+}

--- a/src/main/java/wanted/assignment/member/service/MemberService.java
+++ b/src/main/java/wanted/assignment/member/service/MemberService.java
@@ -1,11 +1,14 @@
 package wanted.assignment.member.service;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import wanted.assignment.common.error.exception.member.DuplicateEmailException;
+import wanted.assignment.common.error.exception.member.PasswordMismatchException;
+import wanted.assignment.common.generator.Sha256Util;
 import wanted.assignment.member.dao.MemberRepository;
 import wanted.assignment.member.dao.domain.Member;
 import wanted.assignment.member.service.request.MemberCreateServiceRequest;
@@ -17,19 +20,37 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 
 	public Long join(MemberCreateServiceRequest request) {
-		boolean isDuplicateEmail = checkDuplicateEmail(request.getEmail());
-
-		if (isDuplicateEmail) {
-			throw new DuplicateEmailException("이미 사용 중인 이메일입니다.");
-		}
+		checkDuplicateEmail(request.getEmail());
 
 		Member member = Member.createFromServiceRequest(request);
 		return memberRepository.save(member);
 	}
 
-	private boolean checkDuplicateEmail(String email) {
+	public Member signIn(String email, String password) {
+		Member member = getMemberByEmail(email);
+		checkPassword(member, password);
+
+		return member;
+	}
+
+	private void checkDuplicateEmail(String email) {
 		Optional<Member> findEmailOptional = memberRepository.findByEmail(email);
 
-		return findEmailOptional.isPresent();
+		if (findEmailOptional.isPresent()) {
+			throw new DuplicateEmailException("이미 사용 중인 이메일입니다.");
+		}
+	}
+
+	private Member getMemberByEmail(String email) {
+		return memberRepository.findByEmail(email)
+			.orElseThrow(() -> new NoSuchElementException("존재하지 않는 아이디입니다."));
+	}
+
+	private void checkPassword(Member member, String password) {
+		String encryptPassword = Sha256Util.getEncrypt(password);
+
+		if (!member.getPassword().equals(encryptPassword)) {
+			throw new PasswordMismatchException("비밀번호가 일치하지 않습니다.");
+		}
 	}
 }

--- a/src/main/java/wanted/assignment/member/service/request/MemberCreateServiceRequest.java
+++ b/src/main/java/wanted/assignment/member/service/request/MemberCreateServiceRequest.java
@@ -1,0 +1,17 @@
+package wanted.assignment.member.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberCreateServiceRequest {
+
+	private final String email;
+	private final String password;
+
+	@Builder
+	private MemberCreateServiceRequest(String email, String password) {
+		this.email = email;
+		this.password = password;
+	}
+}

--- a/src/main/java/wanted/assignment/member/web/MemberController.java
+++ b/src/main/java/wanted/assignment/member/web/MemberController.java
@@ -20,7 +20,6 @@ public class MemberController {
 	@PostMapping("/api/v1/member")
 	public ApiResult<Long> joinMember(@Valid @RequestBody MemberCreateRequest request) {
 		Long joinedMemberId = memberService.join(request.toServiceRequest());
-		
 		return ApiResult.onSuccess(joinedMemberId);
 	}
 }

--- a/src/main/java/wanted/assignment/member/web/MemberController.java
+++ b/src/main/java/wanted/assignment/member/web/MemberController.java
@@ -8,18 +8,33 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import wanted.assignment.common.basewrapper.ApiResult;
+import wanted.assignment.common.config.jwt.JwtAuthTokenProvider;
+import wanted.assignment.member.dao.domain.Member;
 import wanted.assignment.member.service.MemberService;
 import wanted.assignment.member.web.request.MemberCreateRequest;
+import wanted.assignment.member.web.request.MemberSignInRequest;
+import wanted.assignment.member.web.response.MemberSignInResponse;
 
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
 
 	private final MemberService memberService;
+	private final JwtAuthTokenProvider jwtAuthTokenProvider;
 
-	@PostMapping("/api/v1/member")
-	public ApiResult<Long> joinMember(@Valid @RequestBody MemberCreateRequest request) {
+	@PostMapping("/api/v1/sign-up")
+	public ApiResult<Long> signUpMember(@Valid @RequestBody MemberCreateRequest request) {
 		Long joinedMemberId = memberService.join(request.toServiceRequest());
 		return ApiResult.onSuccess(joinedMemberId);
+	}
+
+	@PostMapping("/api/v1/sign-in")
+	public ApiResult<MemberSignInResponse> signInMember(@Valid @RequestBody MemberSignInRequest request) {
+		Member member = memberService.signIn(request.getEmail(), request.getPassword());
+		String jwtAuthToken = jwtAuthTokenProvider.createJwtAuthToken(member.getId(), member.getEmail());
+
+		MemberSignInResponse response = member.getSignInResponse(jwtAuthToken);
+
+		return ApiResult.onSuccess(response);
 	}
 }

--- a/src/main/java/wanted/assignment/member/web/MemberController.java
+++ b/src/main/java/wanted/assignment/member/web/MemberController.java
@@ -11,8 +11,8 @@ import wanted.assignment.common.basewrapper.ApiResult;
 import wanted.assignment.common.config.jwt.JwtAuthTokenProvider;
 import wanted.assignment.member.dao.domain.Member;
 import wanted.assignment.member.service.MemberService;
-import wanted.assignment.member.web.request.MemberCreateRequest;
 import wanted.assignment.member.web.request.MemberSignInRequest;
+import wanted.assignment.member.web.request.MemberSignUpRequest;
 import wanted.assignment.member.web.response.MemberSignInResponse;
 
 @RestController
@@ -23,14 +23,14 @@ public class MemberController {
 	private final JwtAuthTokenProvider jwtAuthTokenProvider;
 
 	@PostMapping("/api/v1/sign-up")
-	public ApiResult<Long> signUpMember(@Valid @RequestBody MemberCreateRequest request) {
+	public ApiResult<Long> signUpMember(@Valid @RequestBody MemberSignUpRequest request) {
 		Long joinedMemberId = memberService.join(request.toServiceRequest());
 		return ApiResult.onSuccess(joinedMemberId);
 	}
 
 	@PostMapping("/api/v1/sign-in")
 	public ApiResult<MemberSignInResponse> signInMember(@Valid @RequestBody MemberSignInRequest request) {
-		Member member = memberService.signIn(request.getEmail(), request.getPassword());
+		Member member = memberService.login(request.getEmail(), request.getPassword());
 		String jwtAuthToken = jwtAuthTokenProvider.createJwtAuthToken(member.getId(), member.getEmail());
 
 		MemberSignInResponse response = member.getSignInResponse(jwtAuthToken);

--- a/src/main/java/wanted/assignment/member/web/MemberController.java
+++ b/src/main/java/wanted/assignment/member/web/MemberController.java
@@ -1,0 +1,26 @@
+package wanted.assignment.member.web;
+
+import javax.validation.Valid;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import wanted.assignment.common.basewrapper.ApiResult;
+import wanted.assignment.member.service.MemberService;
+import wanted.assignment.member.web.request.MemberCreateRequest;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+	private final MemberService memberService;
+
+	@PostMapping("/api/v1/member")
+	public ApiResult<Long> joinMember(@Valid @RequestBody MemberCreateRequest request) {
+		Long joinedMemberId = memberService.join(request.toServiceRequest());
+		
+		return ApiResult.onSuccess(joinedMemberId);
+	}
+}

--- a/src/main/java/wanted/assignment/member/web/request/MemberCreateRequest.java
+++ b/src/main/java/wanted/assignment/member/web/request/MemberCreateRequest.java
@@ -1,0 +1,34 @@
+package wanted.assignment.member.web.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+import org.hibernate.validator.constraints.Length;
+
+import lombok.Builder;
+import lombok.Getter;
+import wanted.assignment.member.service.request.MemberCreateServiceRequest;
+
+@Getter
+public class MemberCreateRequest {
+
+	@NotBlank(message = "이메일은 필수값입니다.")
+	@Email(message = "올바른 이메일 형식으로 입력해주세요.")
+	private final String email;
+
+	@Length(min = 8, message = "비밀번호는 8자 이상 입력해주세요.")
+	private final String password;
+
+	@Builder
+	private MemberCreateRequest(String email, String password) {
+		this.email = email;
+		this.password = password;
+	}
+
+	public MemberCreateServiceRequest toServiceRequest() {
+		return MemberCreateServiceRequest.builder()
+			.email(this.email)
+			.password(this.password)
+			.build();
+	}
+}

--- a/src/main/java/wanted/assignment/member/web/request/MemberSignInRequest.java
+++ b/src/main/java/wanted/assignment/member/web/request/MemberSignInRequest.java
@@ -1,0 +1,26 @@
+package wanted.assignment.member.web.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+import org.hibernate.validator.constraints.Length;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberSignInRequest {
+
+	@NotBlank(message = "이메일은 필수값입니다.")
+	@Email(message = "올바른 이메일 형식으로 입력해주세요.")
+	private final String email;
+
+	@Length(min = 8, message = "비밀번호는 8자 이상 입력해주세요.")
+	private final String password;
+
+	@Builder
+	private MemberSignInRequest(String email, String password) {
+		this.email = email;
+		this.password = password;
+	}
+}

--- a/src/main/java/wanted/assignment/member/web/request/MemberSignUpRequest.java
+++ b/src/main/java/wanted/assignment/member/web/request/MemberSignUpRequest.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import wanted.assignment.member.service.request.MemberCreateServiceRequest;
 
 @Getter
-public class MemberCreateRequest {
+public class MemberSignUpRequest {
 
 	@NotBlank(message = "이메일은 필수값입니다.")
 	@Email(message = "올바른 이메일 형식으로 입력해주세요.")
@@ -20,7 +20,7 @@ public class MemberCreateRequest {
 	private final String password;
 
 	@Builder
-	private MemberCreateRequest(String email, String password) {
+	private MemberSignUpRequest(String email, String password) {
 		this.email = email;
 		this.password = password;
 	}

--- a/src/main/java/wanted/assignment/member/web/response/MemberSignInResponse.java
+++ b/src/main/java/wanted/assignment/member/web/response/MemberSignInResponse.java
@@ -1,0 +1,18 @@
+package wanted.assignment.member.web.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberSignInResponse {
+	private final Long id;
+	private final String email;
+	private final String token;
+
+	@Builder
+	private MemberSignInResponse(Long id, String email, String token) {
+		this.id = id;
+		this.email = email;
+		this.token = token;
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,11 @@ mybatis:
     map-underscore-to-camel-case: true
   mapper-locations: classpath:mapper/**/*.xml
 
+jwt:
+  secret: 7c8d3c13bd32be41c39655f87737422920037a5ccf569bf8484511cf5241ceec
+  header: x-auth-token
+  expired_minutes: 30
+
 ---
 #-------- product --------
 spring:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -7,8 +7,6 @@ create table member
     id         bigint unsigned primary key auto_increment,
     email      varchar(255) not null,
     password   varchar(40)  not null,
-    name       varchar(40)  not null,
-    username   varchar(40)  not null,
     created_at timestamp    not null,
     updated_at timestamp    not null
 );

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -6,7 +6,7 @@ create table member
 (
     id         bigint unsigned primary key auto_increment,
     email      varchar(255) not null,
-    password   varchar(40)  not null,
+    password   char(64)     not null,
     created_at timestamp    not null,
     updated_at timestamp    not null
 );

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -5,10 +5,10 @@ drop table if exists post_detail;
 create table member
 (
     id         bigint unsigned primary key auto_increment,
-    email      varchar(255) not null,
-    password   char(64)     not null,
-    created_at timestamp    not null,
-    updated_at timestamp    not null
+    email      varchar(255) unique not null,
+    password   char(64)            not null,
+    created_at timestamp           not null,
+    updated_at timestamp           not null
 );
 
 create table post

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="wanted.assignment.member.dao.mybatis.MemberMapper">
+
+    <insert id="save" useGeneratedKeys="true" keyColumn="id" keyProperty="data.id">
+        insert into member (email, password, created_at, updated_at)
+        values (#{data.email}, #{data.password}, #{createdAt}, #{updatedAt})
+    </insert>
+
+    <select id="findById">
+        select *
+        from member
+        where id = #{id}
+    </select>
+
+    <update id="update">
+        update member
+        set email      = #{updateParam.data.email},
+            password   = #{updateParam.data.password},
+            updated_at = #{updateParam.updatedAt}
+        where id = #{id}
+    </update>
+
+    <delete id="delete">
+        delete
+        from member
+        where id = #{id}
+    </delete>
+</mapper>

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -14,6 +14,12 @@
         where id = #{id}
     </select>
 
+    <select id="findByEmail">
+        select *
+        from member
+        where email = #{email}
+    </select>
+
     <update id="update">
         update member
         set email      = #{updateParam.data.email},

--- a/src/test/java/wanted/assignment/common/generator/Sha256UtilTest.java
+++ b/src/test/java/wanted/assignment/common/generator/Sha256UtilTest.java
@@ -1,0 +1,23 @@
+package wanted.assignment.common.generator;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class Sha256UtilTest {
+
+	@Test
+	@DisplayName("단방향 암호화 방식 - 하나의 비밀번호를 여러번 암호화해도 같은 값을 가집니다.")
+	void getEncrypt() {
+		// given
+		String password = "password";
+
+		// when
+		String encrypt1 = Sha256Util.getEncrypt(password);
+		String encrypt2 = Sha256Util.getEncrypt(password);
+
+		// then
+		assertThat(encrypt1).isEqualTo(encrypt2);
+	}
+}

--- a/src/test/java/wanted/assignment/member/dao/mybatis/MyBatisMemberRepositoryTest.java
+++ b/src/test/java/wanted/assignment/member/dao/mybatis/MyBatisMemberRepositoryTest.java
@@ -1,0 +1,109 @@
+package wanted.assignment.member.dao.mybatis;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import wanted.assignment.TestBaseConfig;
+import wanted.assignment.member.dao.MemberRepository;
+import wanted.assignment.member.dao.domain.Member;
+
+@SpringBootTest
+class MyBatisMemberRepositoryTest extends TestBaseConfig {
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("회원을 저장합니다.")
+	void save() {
+		// given
+		Member member = createMember("xxxx@gmail.com", "xxxxxxxx");
+
+		// when
+		Long savedMemberId = memberRepository.save(member);
+
+		// then
+		assertThat(savedMemberId).isEqualTo(1L);
+	}
+
+	@Test
+	@DisplayName("아이디를 사용하여 회원을 찾습니다.")
+	void findById() {
+		// given
+		String email = "xxxx@gmail.com";
+		String password = "xxxxxxxx";
+
+		Member member = createMember(email, password);
+		memberRepository.save(member);
+
+		// when
+		Member findMember = memberRepository.findById(1L);
+
+		// then
+		assertThat(findMember)
+			.extracting("id", "email", "password")
+			.contains(1L, email, password);
+	}
+
+	@Test
+	@DisplayName("아이디를 사용하여 회원 정보를 수정합니다.")
+	void update() {
+		// given
+		String email = "xxxx@gmail.com";
+		String password = "xxxxxxxx";
+
+		Member memberA = createMember(email, password);
+		Long savedMemberId = memberRepository.save(memberA);
+
+		// when
+		String updateEmail = "yyyyy@gmail.com";
+		String updatePassword = "yyyyyyy";
+
+		Member updateMember = createMember(updateEmail, updatePassword);
+		Long updateMemberId = memberRepository.update(savedMemberId, updateMember);
+
+		// then
+		assertThat(updateMemberId).isEqualTo(savedMemberId);
+
+		Member findMember = memberRepository.findById(updateMemberId);
+		assertThat(findMember)
+			.extracting("id", "email", "password")
+			.contains(updateMemberId, updateEmail, updatePassword);
+	}
+
+	@Test
+	@DisplayName("아이디를 사용하여 회원을 삭제합니다.")
+	void delete() {
+		// given
+		String email = "xxxx@gmail.com";
+		String password = "xxxxxxxx";
+
+		Member memberA = createMember(email, password);
+		Long savedMemberId = memberRepository.save(memberA);
+
+		Member findMember = memberRepository.findById(savedMemberId);
+		assertThat(findMember)
+			.extracting("id", "email", "password")
+			.contains(savedMemberId, email, password);
+
+		// when
+		memberRepository.delete(savedMemberId);
+
+		// then
+		assertThatThrownBy(() -> memberRepository.findById(savedMemberId))
+			.isInstanceOf(NoSuchElementException.class);
+	}
+
+	private Member createMember(String email, String password) {
+		return Member.builder()
+			.email(email)
+			.password(password)
+			.build();
+	}
+}

--- a/src/test/java/wanted/assignment/member/service/MemberServiceTest.java
+++ b/src/test/java/wanted/assignment/member/service/MemberServiceTest.java
@@ -1,0 +1,43 @@
+package wanted.assignment.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import wanted.assignment.TestBaseConfig;
+import wanted.assignment.member.dao.MemberRepository;
+import wanted.assignment.member.dao.domain.Member;
+import wanted.assignment.member.service.request.MemberCreateServiceRequest;
+
+class MemberServiceTest extends TestBaseConfig {
+
+	@Autowired
+	private MemberService memberService;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Test
+	@DisplayName("Request DTO를 받아 비밀번호 암호화 후 DB에 저장합니다.")
+	void join() {
+		// given
+		String email = "xxxxx@gmail.com";
+		String password = "xxxxxxx";
+
+		MemberCreateServiceRequest request = MemberCreateServiceRequest.builder()
+			.email(email)
+			.password(password)
+			.build();
+
+		// when
+		Long joinedMemberId = memberService.join(request);
+
+		// then
+		assertThat(joinedMemberId).isEqualTo(1L);
+
+		Member findMember = memberRepository.findById(joinedMemberId);
+		assertThat(findMember.getPassword()).isNotEqualTo(password);
+	}
+}

--- a/src/test/java/wanted/assignment/member/service/MemberServiceTest.java
+++ b/src/test/java/wanted/assignment/member/service/MemberServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import wanted.assignment.TestBaseConfig;
+import wanted.assignment.common.error.exception.member.DuplicateEmailException;
 import wanted.assignment.member.dao.MemberRepository;
 import wanted.assignment.member.dao.domain.Member;
 import wanted.assignment.member.service.request.MemberCreateServiceRequest;
@@ -19,17 +20,14 @@ class MemberServiceTest extends TestBaseConfig {
 	@Autowired
 	private MemberRepository memberRepository;
 
+	private final String email = "xxxxx@gmail.com";
+	private final String password = "xxxxxxx";
+
 	@Test
 	@DisplayName("Request DTO를 받아 비밀번호 암호화 후 DB에 저장합니다.")
 	void join() {
 		// given
-		String email = "xxxxx@gmail.com";
-		String password = "xxxxxxx";
-
-		MemberCreateServiceRequest request = MemberCreateServiceRequest.builder()
-			.email(email)
-			.password(password)
-			.build();
+		MemberCreateServiceRequest request = getMemberCreateServiceRequest(email, password);
 
 		// when
 		Long joinedMemberId = memberService.join(request);
@@ -39,5 +37,24 @@ class MemberServiceTest extends TestBaseConfig {
 
 		Member findMember = memberRepository.findById(joinedMemberId);
 		assertThat(findMember.getPassword()).isNotEqualTo(password);
+	}
+
+	@Test
+	@DisplayName("이미 사용 중인 이메일이라면 예외를 던집니다.")
+	void isDuplicateEmail() {
+		// given
+		MemberCreateServiceRequest request = getMemberCreateServiceRequest(email, password);
+		memberService.join(request);
+
+		// when  // then
+		assertThatThrownBy(() -> memberService.join(request))
+			.isInstanceOf(DuplicateEmailException.class);
+	}
+
+	private MemberCreateServiceRequest getMemberCreateServiceRequest(String email, String password) {
+		return MemberCreateServiceRequest.builder()
+			.email(email)
+			.password(password)
+			.build();
 	}
 }

--- a/src/test/java/wanted/assignment/member/web/MemberControllerTest.java
+++ b/src/test/java/wanted/assignment/member/web/MemberControllerTest.java
@@ -1,0 +1,112 @@
+package wanted.assignment.member.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import wanted.assignment.member.service.MemberService;
+import wanted.assignment.member.web.request.MemberCreateRequest;
+
+@WebMvcTest(controllers = MemberController.class)
+class MemberControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private MemberService memberService;
+
+	@Test
+	@DisplayName("회원을 등록합니다.")
+	void joinMember() throws Exception {
+		// given
+		MemberCreateRequest request = MemberCreateRequest.builder()
+			.email("xxxxx@yyyyy")
+			.password("yyyyyyyyyyy")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				post("/api/v1/member")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("회원 가입에는 이메일이 필수입니다.")
+	void joinMemberWithoutEmail() throws Exception {
+		// given
+		MemberCreateRequest request = MemberCreateRequest.builder()
+			.password("yyyyyyyy")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				post("/api/v1/member")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("이메일은 필수값입니다."));
+	}
+
+	@Test
+	@DisplayName("회원 가입 시 이메일 형식을 지켜야합니다. (@ 포함)")
+	void joinMemberWithoutEmailFormat() throws Exception {
+		// given
+		MemberCreateRequest request = MemberCreateRequest.builder()
+			.email("xxxxxxx")
+			.password("yyyyyyyy")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				post("/api/v1/member")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("올바른 이메일 형식으로 입력해주세요."));
+	}
+
+	@Test
+	@DisplayName("비밀번호는 8자 이상 입력해야 합니다.")
+	void joinMemberWithoutPasswordFormat() throws Exception {
+		// given
+		MemberCreateRequest request = MemberCreateRequest.builder()
+			.email("xxxxxxx@yyyyyyyyy")
+			.password("yy")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				post("/api/v1/member")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.data").doesNotExist())
+			.andExpect(jsonPath("$.message").value("비밀번호는 8자 이상 입력해주세요."));
+	}
+}

--- a/src/test/java/wanted/assignment/member/web/MemberControllerTest.java
+++ b/src/test/java/wanted/assignment/member/web/MemberControllerTest.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import wanted.assignment.common.config.jwt.JwtAuthTokenProvider;
 import wanted.assignment.member.service.MemberService;
-import wanted.assignment.member.web.request.MemberCreateRequest;
+import wanted.assignment.member.web.request.MemberSignUpRequest;
 
 @WebMvcTest(controllers = MemberController.class)
 class MemberControllerTest {
@@ -37,7 +37,7 @@ class MemberControllerTest {
 	@DisplayName("회원을 등록합니다.")
 	void joinMember() throws Exception {
 		// given
-		MemberCreateRequest request = MemberCreateRequest.builder()
+		MemberSignUpRequest request = MemberSignUpRequest.builder()
 			.email("xxxxx@yyyyy")
 			.password("yyyyyyyyyyy")
 			.build();
@@ -56,7 +56,7 @@ class MemberControllerTest {
 	@DisplayName("회원 가입에는 이메일이 필수입니다.")
 	void joinMemberWithoutEmail() throws Exception {
 		// given
-		MemberCreateRequest request = MemberCreateRequest.builder()
+		MemberSignUpRequest request = MemberSignUpRequest.builder()
 			.password("yyyyyyyy")
 			.build();
 
@@ -76,7 +76,7 @@ class MemberControllerTest {
 	@DisplayName("회원 가입 시 이메일 형식을 지켜야합니다. (@ 포함)")
 	void joinMemberWithoutEmailFormat() throws Exception {
 		// given
-		MemberCreateRequest request = MemberCreateRequest.builder()
+		MemberSignUpRequest request = MemberSignUpRequest.builder()
 			.email("xxxxxxx")
 			.password("yyyyyyyy")
 			.build();
@@ -97,7 +97,7 @@ class MemberControllerTest {
 	@DisplayName("비밀번호는 8자 이상 입력해야 합니다.")
 	void joinMemberWithoutPasswordFormat() throws Exception {
 		// given
-		MemberCreateRequest request = MemberCreateRequest.builder()
+		MemberSignUpRequest request = MemberSignUpRequest.builder()
 			.email("xxxxxxx@yyyyyyyyy")
 			.password("yy")
 			.build();

--- a/src/test/java/wanted/assignment/member/web/MemberControllerTest.java
+++ b/src/test/java/wanted/assignment/member/web/MemberControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import wanted.assignment.common.config.jwt.JwtAuthTokenProvider;
 import wanted.assignment.member.service.MemberService;
 import wanted.assignment.member.web.request.MemberCreateRequest;
 
@@ -29,6 +30,9 @@ class MemberControllerTest {
 	@MockBean
 	private MemberService memberService;
 
+	@MockBean
+	private JwtAuthTokenProvider jwtAuthTokenProvider;
+
 	@Test
 	@DisplayName("회원을 등록합니다.")
 	void joinMember() throws Exception {
@@ -40,7 +44,7 @@ class MemberControllerTest {
 
 		// when // then
 		mockMvc.perform(
-				post("/api/v1/member")
+				post("/api/v1/sign-up")
 					.content(objectMapper.writeValueAsString(request))
 					.contentType(MediaType.APPLICATION_JSON)
 			)
@@ -58,7 +62,7 @@ class MemberControllerTest {
 
 		// when // then
 		mockMvc.perform(
-				post("/api/v1/member")
+				post("/api/v1/sign-up")
 					.content(objectMapper.writeValueAsString(request))
 					.contentType(MediaType.APPLICATION_JSON)
 			)
@@ -79,7 +83,7 @@ class MemberControllerTest {
 
 		// when // then
 		mockMvc.perform(
-				post("/api/v1/member")
+				post("/api/v1/sign-up")
 					.content(objectMapper.writeValueAsString(request))
 					.contentType(MediaType.APPLICATION_JSON)
 			)
@@ -100,7 +104,7 @@ class MemberControllerTest {
 
 		// when // then
 		mockMvc.perform(
-				post("/api/v1/member")
+				post("/api/v1/sign-up")
 					.content(objectMapper.writeValueAsString(request))
 					.contentType(MediaType.APPLICATION_JSON)
 			)


### PR DESCRIPTION
## 회원 가입 및 로그인 기능 구현
- 회원 가입 시 데이터베이스에 비밀번호를  SHA256 알고리즘을 사용하여 암호화 저장
- 로그인 시 JWT를 사용하여 클라이언트에게 토큰 발행
- 회원 가입 및 로그인의 RequestBody에 유효성 검사 추가
- 회원가입 및 로그인 테스트 코드 작성